### PR TITLE
[BE][UP-101] 프론트 연결 위한 백엔드 소셜 로그인 코드 수정 및 장르 리스트 전송 api

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/business/auth/GoogleService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/GoogleService.java
@@ -1,11 +1,9 @@
 package com.ureca.picky_be.base.business.auth;
 
-import com.ureca.picky_be.base.business.auth.dto.DeleteUserReq;
-import com.ureca.picky_be.base.business.auth.dto.LoginUrlResp;
-import com.ureca.picky_be.base.business.auth.dto.LoginUserInfo;
-import com.ureca.picky_be.base.business.auth.dto.OAuth2Token;
+import com.ureca.picky_be.base.business.auth.dto.*;
 import com.ureca.picky_be.base.implementation.auth.AuthManager;
 import com.ureca.picky_be.base.implementation.auth.GoogleManager;
+import com.ureca.picky_be.base.implementation.mapper.OAuth2DtoMapper;
 import com.ureca.picky_be.global.success.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +14,7 @@ public class GoogleService implements OAuth2UseCase{
 
     private final GoogleManager googleManager;
     private final AuthManager authManager;
+    private final OAuth2DtoMapper oAuth2DtoMapper;
 
     //TODO: state 랜덤 생성 및 유효성 검사
     private String state="1234";
@@ -26,14 +25,13 @@ public class GoogleService implements OAuth2UseCase{
     }
 
     @Override
-    public SuccessCode sendJwtToken(String state, String code) {
+    public TokenResp sendJwtToken(String state, String code) {
         OAuth2Token oAuth2Token = googleManager.getOAuth2Token(code);
         String email = googleManager.getUserInfo(oAuth2Token.accessToken());
         LoginUserInfo loginUserInfo = googleManager.getLocalJwt(email, oAuth2Token.accessToken());
         System.out.println(loginUserInfo);
         System.out.println(oAuth2Token);
-
-        return googleManager.sendResponseToFrontend(oAuth2Token, loginUserInfo.jwt(), googleManager.isRegistrationDone(loginUserInfo.userId()));
+        return oAuth2DtoMapper.toTokenResp(oAuth2Token, loginUserInfo.jwt(), googleManager.isRegistrationDone(authManager.getUserId()));
     }
 
     @Override

--- a/src/main/java/com/ureca/picky_be/base/business/auth/KakaoService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/KakaoService.java
@@ -1,11 +1,9 @@
 package com.ureca.picky_be.base.business.auth;
 
-import com.ureca.picky_be.base.business.auth.dto.DeleteUserReq;
-import com.ureca.picky_be.base.business.auth.dto.LoginUrlResp;
-import com.ureca.picky_be.base.business.auth.dto.LoginUserInfo;
-import com.ureca.picky_be.base.business.auth.dto.OAuth2Token;
+import com.ureca.picky_be.base.business.auth.dto.*;
 import com.ureca.picky_be.base.implementation.auth.AuthManager;
 import com.ureca.picky_be.base.implementation.auth.KakaoManager;
+import com.ureca.picky_be.base.implementation.mapper.OAuth2DtoMapper;
 import com.ureca.picky_be.global.success.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -16,6 +14,7 @@ public class KakaoService implements OAuth2UseCase {
 
     private final KakaoManager kakaoManager;
     private final AuthManager authManager;
+    private final OAuth2DtoMapper oAuth2DtoMapper;
 
     //TODO: state 랜덤 생성 및 유효성 검사
     private String state="1234";
@@ -26,14 +25,13 @@ public class KakaoService implements OAuth2UseCase {
     }
 
     @Override
-    public SuccessCode sendJwtToken(String state, String code) {
+    public TokenResp sendJwtToken(String state, String code) {
         OAuth2Token oAuth2Token = kakaoManager.getOAuth2Token(code);
         String email = kakaoManager.getUserInfo(oAuth2Token.accessToken());
         LoginUserInfo loginUserInfo = kakaoManager.getLocalJwt(email, oAuth2Token.accessToken());
         System.out.println(loginUserInfo);
         System.out.println(oAuth2Token);
-
-        return kakaoManager.sendResponseToFrontend(oAuth2Token, loginUserInfo.jwt(), kakaoManager.isRegistrationDone(authManager.getUserId()));
+        return oAuth2DtoMapper.toTokenResp(oAuth2Token, loginUserInfo.jwt(), kakaoManager.isRegistrationDone(authManager.getUserId()));
     }
 
     @Override

--- a/src/main/java/com/ureca/picky_be/base/business/auth/NaverService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/NaverService.java
@@ -1,12 +1,10 @@
 package com.ureca.picky_be.base.business.auth;
 
 
-import com.ureca.picky_be.base.business.auth.dto.DeleteUserReq;
-import com.ureca.picky_be.base.business.auth.dto.LoginUrlResp;
-import com.ureca.picky_be.base.business.auth.dto.LoginUserInfo;
-import com.ureca.picky_be.base.business.auth.dto.OAuth2Token;
+import com.ureca.picky_be.base.business.auth.dto.*;
 import com.ureca.picky_be.base.implementation.auth.AuthManager;
 import com.ureca.picky_be.base.implementation.auth.NaverManager;
+import com.ureca.picky_be.base.implementation.mapper.OAuth2DtoMapper;
 import com.ureca.picky_be.global.success.SuccessCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -17,6 +15,7 @@ public class NaverService implements OAuth2UseCase{
 
     private final NaverManager naverManager;
     private final AuthManager authManager;
+    private final OAuth2DtoMapper oAuth2DtoMapper;
 
     //TODO: state 랜덤 생성 및 유효성 검사
     private String state="1234";
@@ -27,14 +26,13 @@ public class NaverService implements OAuth2UseCase{
     }
 
     @Override
-    public SuccessCode sendJwtToken(String state, String code) {
+    public TokenResp sendJwtToken(String state, String code) {
         OAuth2Token oAuth2Token = naverManager.getOAuth2Token(state, code);
         String email = naverManager.getUserInfo(oAuth2Token.accessToken());
         LoginUserInfo loginUserInfo = naverManager.getLocalJwt(email);
         System.out.println(loginUserInfo);
         System.out.println(oAuth2Token);
-
-        return naverManager.sendResponseToFrontend(oAuth2Token, loginUserInfo.jwt(), naverManager.isRegistrationDone(authManager.getUserId()));
+        return oAuth2DtoMapper.toTokenResp(oAuth2Token, loginUserInfo.jwt(), naverManager.isRegistrationDone(authManager.getUserId()));
     }
 
     @Override

--- a/src/main/java/com/ureca/picky_be/base/business/auth/OAuth2UseCase.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/OAuth2UseCase.java
@@ -2,11 +2,12 @@ package com.ureca.picky_be.base.business.auth;
 
 import com.ureca.picky_be.base.business.auth.dto.DeleteUserReq;
 import com.ureca.picky_be.base.business.auth.dto.LoginUrlResp;
+import com.ureca.picky_be.base.business.auth.dto.TokenResp;
 import com.ureca.picky_be.global.success.SuccessCode;
 
 public interface OAuth2UseCase {
 
     LoginUrlResp getLoginUrl();
-    SuccessCode sendJwtToken(String state, String code);
+    TokenResp sendJwtToken(String state, String code);
     SuccessCode deleteAccount(DeleteUserReq req);
 }

--- a/src/main/java/com/ureca/picky_be/base/business/auth/dto/LoginUserResp.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/dto/LoginUserResp.java
@@ -1,8 +1,0 @@
-package com.ureca.picky_be.base.business.auth.dto;
-
-import com.ureca.picky_be.global.web.LocalJwtDto;
-
-public record LoginUserResp (OAuth2Token oAuth2Token,
-                             LocalJwtDto localJwtDto,
-                             boolean isRegistrationDone) {
-}

--- a/src/main/java/com/ureca/picky_be/base/business/auth/dto/TokenResp.java
+++ b/src/main/java/com/ureca/picky_be/base/business/auth/dto/TokenResp.java
@@ -1,0 +1,8 @@
+package com.ureca.picky_be.base.business.auth.dto;
+
+import com.ureca.picky_be.global.web.LocalJwtDto;
+
+public record TokenResp(OAuth2Token oAuth2Token,
+                        LocalJwtDto localJwtDto,
+                        boolean isRegistrationDone) {
+}

--- a/src/main/java/com/ureca/picky_be/base/business/movie/MovieService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/movie/MovieService.java
@@ -10,7 +10,6 @@ import com.ureca.picky_be.jpa.movie.FilmCrew;
 import com.ureca.picky_be.jpa.movie.Movie;
 import com.ureca.picky_be.jpa.movie.MovieBehindVideo;
 import lombok.RequiredArgsConstructor;
-import org.springframework.data.domain.Slice;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -75,5 +74,11 @@ public class MovieService implements MovieUseCase{
     @Override
     public boolean movieLike(Long movieId){
         return movieManager.movieLike(movieId, authManager.getUserId());
+    }
+
+    @Override
+    public List<GetGenres> getGenres(){
+        List<Genre> genres = movieManager.getGenres();
+        return movieDtoMapper.toGetGenres(genres);
     }
 }

--- a/src/main/java/com/ureca/picky_be/base/business/movie/MovieUseCase.java
+++ b/src/main/java/com/ureca/picky_be/base/business/movie/MovieUseCase.java
@@ -15,4 +15,5 @@ public interface MovieUseCase {
     List<GetSimpleMovieResp> getTop10();
     List<GetSimpleMovieResp> getMoviesByGenre(Long genreId, Long lastMovieId, Integer lastLikeCount);
     boolean movieLike(Long movieId);
+    List<GetGenres> getGenres();
 }

--- a/src/main/java/com/ureca/picky_be/base/business/movie/dto/GetGenres.java
+++ b/src/main/java/com/ureca/picky_be/base/business/movie/dto/GetGenres.java
@@ -1,0 +1,4 @@
+package com.ureca.picky_be.base.business.movie.dto;
+
+public record GetGenres(Long genreId, String name) {
+}

--- a/src/main/java/com/ureca/picky_be/base/business/user/dto/UpdateUserReq.java
+++ b/src/main/java/com/ureca/picky_be/base/business/user/dto/UpdateUserReq.java
@@ -12,5 +12,6 @@ public record UpdateUserReq(String name,
                             LocalDate birthdate,
                             Gender gender,
                             Nationality nationality,
-                            List<Long> movieId){
+                            List<Long> movieId,
+                            List<Long> genreId){
 }

--- a/src/main/java/com/ureca/picky_be/base/implementation/auth/GoogleManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/auth/GoogleManager.java
@@ -147,31 +147,6 @@ public class GoogleManager {
         }
     }
 
-    public SuccessCode sendResponseToFrontend(OAuth2Token oAuth2Token, LocalJwtDto jwt, boolean isRegistrationDone) {
-        LoginUserResp resp = new LoginUserResp(oAuth2Token, jwt, isRegistrationDone);
-        try {
-            restClient
-                    .post()
-                    .uri(buildFrontendUrl())
-                    .header("Content-Type", "application/json")
-                    .body(resp)
-                    .retrieve()
-                    .toBodilessEntity();
-            return SuccessCode.REQUEST_FRONT_SUCCESS;
-        } catch (RestClientResponseException e) {
-            throw new CustomException(ErrorCode.BAD_REQUEST);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    private String buildFrontendUrl(){
-        return UriComponentsBuilder
-                .fromHttpUrl(googleConfig.getFrontendServer())
-                .build()
-                .toUriString();
-    }
-
     @Transactional
     public SuccessCode deleteAccount(Long userId, DeleteUserReq req) {
         restClient

--- a/src/main/java/com/ureca/picky_be/base/implementation/auth/KakaoManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/auth/KakaoManager.java
@@ -151,31 +151,6 @@ public class KakaoManager {
         }
     }
 
-    public SuccessCode sendResponseToFrontend(OAuth2Token oAuth2Token, LocalJwtDto jwt, boolean isRegistrationDone) {
-        LoginUserResp resp = new LoginUserResp(oAuth2Token, jwt, isRegistrationDone);
-        try {
-            restClient
-                    .post()
-                    .uri(buildFrontendUrl())
-                    .header("Content-Type", "application/json")
-                    .body(resp)
-                    .retrieve()
-                    .toBodilessEntity();
-            return SuccessCode.REQUEST_FRONT_SUCCESS;
-        } catch (RestClientResponseException e) {
-            throw new CustomException(ErrorCode.BAD_REQUEST);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    private String buildFrontendUrl(){
-        return UriComponentsBuilder
-                .fromHttpUrl(kakaoConfig.getFrontendServer())
-                .build()
-                .toUriString();
-    }
-
     @Transactional
     public SuccessCode deleteAccount(Long userId, DeleteUserReq req) {
         restClient

--- a/src/main/java/com/ureca/picky_be/base/implementation/auth/NaverManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/auth/NaverManager.java
@@ -146,31 +146,6 @@ public class NaverManager {
         }
     }
 
-    public SuccessCode sendResponseToFrontend(OAuth2Token oAuth2Token, LocalJwtDto jwt, boolean isRegistrationDone) {
-        LoginUserResp resp = new LoginUserResp(oAuth2Token, jwt, isRegistrationDone);
-        try {
-            restClient
-                    .post()
-                    .uri(buildFrontendUrl())
-                    .header("Content-Type", "application/json")
-                    .body(resp)
-                    .retrieve()
-                    .toBodilessEntity();
-            return SuccessCode.REQUEST_FRONT_SUCCESS;
-        } catch (RestClientResponseException e) {
-            throw new CustomException(ErrorCode.BAD_REQUEST);
-        } catch (Exception e) {
-            throw new CustomException(ErrorCode.INTERNAL_SERVER_ERROR);
-        }
-    }
-
-    private String buildFrontendUrl(){
-        return UriComponentsBuilder
-                .fromHttpUrl(naverConfig.getFrontendServer())
-                .build()
-                .toUriString();
-    }
-
     @Transactional
     public SuccessCode deleteAccount(Long userId, DeleteUserReq req) {
         restClient

--- a/src/main/java/com/ureca/picky_be/base/implementation/mapper/MovieDtoMapper.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/mapper/MovieDtoMapper.java
@@ -1,5 +1,6 @@
 package com.ureca.picky_be.base.implementation.mapper;
 
+import com.ureca.picky_be.base.business.movie.dto.GetGenres;
 import com.ureca.picky_be.base.business.movie.dto.GetMovieDetailResp;
 import com.ureca.picky_be.base.business.movie.dto.MoviePreferenceResp;
 import com.ureca.picky_be.jpa.genre.Genre;
@@ -70,6 +71,12 @@ public class MovieDtoMapper {
     public List<MoviePreferenceResp> toMoviePreferenceResp(List<Movie> movies) {
         return movies.stream()
                 .map(movie -> new MoviePreferenceResp(movie.getId(), movie.getPosterUrl()))
+                .toList();
+    }
+
+    public List<GetGenres> toGetGenres(List<Genre> genres) {
+        return genres.stream()
+                .map(genre -> new GetGenres(genre.getId(), genre.getName()))
                 .toList();
     }
 

--- a/src/main/java/com/ureca/picky_be/base/implementation/mapper/OAuth2DtoMapper.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/mapper/OAuth2DtoMapper.java
@@ -1,0 +1,17 @@
+package com.ureca.picky_be.base.implementation.mapper;
+
+import com.ureca.picky_be.base.business.auth.dto.OAuth2Token;
+import com.ureca.picky_be.base.business.auth.dto.TokenResp;
+import com.ureca.picky_be.global.web.LocalJwtDto;
+import org.springframework.stereotype.Component;
+
+@Component
+public class OAuth2DtoMapper {
+    public TokenResp toTokenResp(OAuth2Token oAuth2Token, LocalJwtDto localJwtDto, boolean isRegistrationDone) {
+        return new TokenResp(
+                oAuth2Token,
+                localJwtDto,
+                isRegistrationDone
+        );
+    }
+}

--- a/src/main/java/com/ureca/picky_be/base/implementation/movie/MovieManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/movie/MovieManager.java
@@ -310,4 +310,8 @@ public class MovieManager {
             throw new CustomException(ErrorCode.MOVIE_LIKE_FAILED);
         }
     }
+
+    public List<Genre> getGenres(){
+        return genreRepository.findAll();
+    }
 }

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/auth/OAuth2Controller.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/auth/OAuth2Controller.java
@@ -4,6 +4,7 @@ import com.ureca.picky_be.base.business.auth.OAuth2UseCase;
 import com.ureca.picky_be.base.business.auth.OAuth2UseCaseResolver;
 import com.ureca.picky_be.base.business.auth.dto.DeleteUserReq;
 import com.ureca.picky_be.base.business.auth.dto.LoginUrlResp;
+import com.ureca.picky_be.base.business.auth.dto.TokenResp;
 import com.ureca.picky_be.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -22,12 +23,11 @@ public class OAuth2Controller {
         return oAuth2UseCase.getLoginUrl();
     }
 
-    //TODO: 수정필요
-    @Operation(summary = "플랫폼에서 요청 수신 (우리 프론트 사용X)", description = "내부에 프론트로 post요청 보내는 로직 있음(oAuth2Token, jwt, isRegisterationDone) 개발시 백엔드 김00에게 문의 바람- 협의 필요")
+    @Operation(summary = "프론트에서 code 받아서 토큰 반환", description = "localToken, socialToken, isRegistrationDone return 됨 확인 필!")
     @GetMapping("/{platform}/user")
-    public SuccessCode getUserInfo(@PathVariable String platform,
-                                   @RequestParam String code,
-                                   @RequestParam String state
+    public TokenResp getToken(@PathVariable String platform,
+                              @RequestParam String code,
+                              @RequestParam String state
                                             ){
         OAuth2UseCase oAuth2UseCase = oAuth2UseCaseResolver.resolve(platform);
         return oAuth2UseCase.sendJwtToken(state, code);

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/movie/MovieController.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/movie/MovieController.java
@@ -1,10 +1,8 @@
 package com.ureca.picky_be.base.presentation.controller.movie;
 
-import com.ureca.picky_be.base.business.movie.MovieService;
-import com.ureca.picky_be.base.business.movie.dto.AddMovieReq;
-import com.ureca.picky_be.base.business.movie.dto.GetMovieDetailResp;
-import com.ureca.picky_be.base.business.movie.dto.GetSimpleMovieResp;
-import com.ureca.picky_be.base.business.movie.dto.UpdateMovieReq;
+import com.ureca.picky_be.base.business.movie.MovieUseCase;
+import com.ureca.picky_be.base.business.movie.dto.*;
+import com.ureca.picky_be.base.implementation.mapper.MovieDtoMapper;
 import com.ureca.picky_be.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import lombok.RequiredArgsConstructor;
@@ -16,36 +14,36 @@ import java.util.List;
 @RequiredArgsConstructor
 @RequestMapping("/api/v1/movie")
 public class MovieController {
-    private final MovieService movieService;
+    private final MovieUseCase movieUseCase;
 
     @Operation(summary = "영화 등록", description = "영화 등록 api - 담당자 김")
     @PostMapping
     public SuccessCode addMovie(@RequestBody AddMovieReq addMovieReq) {
-        return movieService.addMovie(addMovieReq);
+        return movieUseCase.addMovie(addMovieReq);
     }
 
     @Operation(summary = "영화 상세 정보", description = "영화 상세 정보 api - 담당자 김")
     @GetMapping("/{movieId}")
     public GetMovieDetailResp getMovieDetails(@PathVariable Long movieId) {
-        return movieService.getMovieDetail(movieId);
+        return movieUseCase.getMovieDetail(movieId);
     }
 
     @Operation(summary = "영화 정보 업데이트", description = "영화 정보 업데이트 api - 담당자 김")
     @PatchMapping("/{movieId}")
     public SuccessCode updateMovie(@PathVariable Long movieId, @RequestBody UpdateMovieReq updateMovieReq) {
-        return movieService.updateMovie(movieId, updateMovieReq);
+        return movieUseCase.updateMovie(movieId, updateMovieReq);
     }
 
     @Operation(summary = "영화 추천 리스트(30개)", description = "AI 개발 완료 전까지 임시로 랜덤으로 보냅니다. 프론트에서는 그냥 그대로 개발하시면 됩나다.")
     @GetMapping("/recommend")
     public List<GetSimpleMovieResp> getRecommendMovies() {
-        return movieService.getRecommends();
+        return movieUseCase.getRecommends();
     }
 
     @Operation(summary = "영화 top10", description = "평점 기준 top 10 보냅니다 (임시입니다 나중에 멋진 로직 짤 예정)")
     @GetMapping("/top10")
     public List<GetSimpleMovieResp> getTop10Movies() {
-        return movieService.getTop10();
+        return movieUseCase.getTop10();
     }
 
     @Operation(summary = "영화 장르별 조회", description = "영화 장르별 조회")
@@ -53,15 +51,13 @@ public class MovieController {
     public List<GetSimpleMovieResp> getMoviesByGenre(@RequestParam Long genreId,
                                                      @RequestParam(required = false) Long lastMovieId,
                                                      @RequestParam(required = false) Integer lastLikeCount) {
-        System.out.println(genreId);
-        System.out.println(lastMovieId);
-        System.out.println(lastLikeCount);
-        return movieService.getMoviesByGenre(genreId, lastMovieId, lastLikeCount);
+        return movieUseCase.getMoviesByGenre(genreId, lastMovieId, lastLikeCount);
     }
 
     @Operation(summary = "영화 좋아요", description = "영화 좋아요 혹은 좋아요 취소. return true일 시 좋아요 눌린 상태, false일 시 좋아요 안 눌린 상태")
     @PostMapping("/{movieId}/like")
     public boolean movieLike(@PathVariable Long movieId){
-        return movieService.movieLike(movieId);
+        return movieUseCase.movieLike(movieId);
     }
+
 }

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/user/UserController.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/user/UserController.java
@@ -1,6 +1,7 @@
 package com.ureca.picky_be.base.presentation.controller.user;
 
 import com.ureca.picky_be.base.business.movie.MovieUseCase;
+import com.ureca.picky_be.base.business.movie.dto.GetGenres;
 import com.ureca.picky_be.base.business.movie.dto.MoviePreferenceResp;
 import com.ureca.picky_be.base.business.user.UserUseCase;
 import com.ureca.picky_be.base.business.user.dto.GetUserResp;
@@ -19,7 +20,7 @@ public class UserController {
     private final UserUseCase userUseCase;
     private final MovieUseCase movieUseCase;
 
-    @Operation(summary = "첫 화면에서 유저 개인정보 기입, 및 마이페이지에서 개인정보 수정", description = "처음에 회원가입할 때 개인정보 넣을 때, 마이페이지에서 개인정보 수정할 때 둘 다 사용가능합니다. 다만 필드는 null불가입니다 다 채워서 보내주세요 (마이페이지에서 개인정보 수정하는 부분이라면 기존 정보 넣어서 전송)")
+    @Operation(summary = "회원가입할 때 개인정보 기입, 마이페이지에서 개인정보 수정", description = "무조건 모든 필드 다 채워서 주세요. movieId, genreId 말고는 null 불가")
     @PatchMapping
     public SuccessCode updateUserInfo(@RequestBody UpdateUserReq req) {
         return userUseCase.updateUserInfo(req);
@@ -36,4 +37,12 @@ public class UserController {
     public List<MoviePreferenceResp> getMovieListForPreference(){
         return movieUseCase.getMovieListForPreference();
     }
+
+    @Operation(summary ="장르 전체 리스트 반환", description = "회원가입 때 쓸 일 있으시면 쓰세요.")
+    @GetMapping("/genres")
+    public List<GetGenres> getGenres() {
+        return movieUseCase.getGenres();
+    }
+
+
 }

--- a/src/main/java/com/ureca/picky_be/jpa/user/User.java
+++ b/src/main/java/com/ureca/picky_be/jpa/user/User.java
@@ -7,7 +7,6 @@ import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
 
 import java.time.LocalDate;
-import java.util.Date;
 
 @Getter
 @Entity


### PR DESCRIPTION

## 📝 관련 이슈
- [UP-101] #61 
</br>

## 💻 작업 내용
- 프론트 연결 위한 백엔드 소셜 로그인 코드 수정 및 장르 리스트 전송 api
</br>

## 🙇 특이 사항
- 프론트와 소셜로그인 로직 변경으로 코드 수정이 있었습니다
- 장르 리스트 전부 받는 api 개발
- 그런데 회원가입할 때: 회원가입 -> 개인 정보 기입 -> 선호 장르 선택 -> 좋아하는 영화 선택이라는 로직으로 피그마에 구현이 되어있더라고요. 근데 제 기억에 영화 선택하면 그 중에서 많이 선택된 장르가 선호 장르에 들어가는 걸로 기억을했고 그렇게 구현을 했었었단 말이죠. 근데 피그마 보니까 그게 아닌 것 같길래 우선 선택한 장르는 선호장르에 넣어두고 영화 선택한 건 영화 좋아요 눌린 걸로 표시를 해뒀습니다. 근데 이 부분은 한 번 말해봐야 할 것 같아요. 특별한 로직이 있는게 아니라면 지금 제 머릿속에 드는 생각은, 우리 선호 장르마다 value있잖아요. 거기다가 선택한 영화랑 선택한 장르의 value를 다 더해줄까 싶기도 합니다.
</br>

## 👻 리뷰 요구사항 (선택)
- 위에 말씀드린 게 전부입니다. 지금 밤이라 말이 좀 횡설수설한 것 같은데 내일 만나서 얘기해봐요
</br>

## pr 체크리스트
- [x] 담당자 & 리뷰어 & label 설정
- [x] 제목 규칙 준수 및 예시 삭제
- [x] 코드 정상 실행 확인
