### PR TITLE
[BE][UP-106] 쿼리 최적화를 위한 작성자 닉네임 필드 추가

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/implementation/board/BoardManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/board/BoardManager.java
@@ -34,11 +34,15 @@ public class BoardManager {
         Movie movie = movieRepository.findById(req.movieId())
                 .orElseThrow(() -> new CustomException(ErrorCode.MOVIE_NOT_FOUND));
 
+        // Todo : userId로 등록한 시큐리티에서 user 닉네임 가져오기 -> Board.of에 매개변수로 추가하기
+        String writerNickname = "temp";         // 임시 닉네임
+
         if(req.contents().size() > 5) {
             throw new CustomException(ErrorCode.BOARD_CONTENT_OVER_FIVE);
         }
+
         // TODO: S3 연동
-        Board board = Board.of(userId, movie, req.boardContext(), req.isSpoiler(), req.contents());
+        Board board = Board.of(userId, movie, req.boardContext(), req.isSpoiler(), req.contents(), writerNickname);
         boardRepository.save(board);
     }
 
@@ -74,12 +78,11 @@ public class BoardManager {
     public void addBoardComment(String context, Long boardId, Long userId) {
         Board board = boardRepository.findById(boardId)
                 .orElseThrow(() -> new CustomException(ErrorCode.BOARD_NOT_FOUND));
-        BoardComment comment = BoardComment.builder()
-                .context(context)
-                .userId(userId)
-                .board(board)
-                .build();
 
+        // Todo : userId로 등록한 시큐리티에서 user 닉네임 가져오기 -> Board.of에 매개변수로 추가하기
+        String writerNickname = "temp";         // 임시 닉네임
+
+        BoardComment comment = BoardComment.of(board, userId, context, writerNickname);
         boardCommentRepository.save(comment);
     }
 }

--- a/src/main/java/com/ureca/picky_be/base/implementation/lineReview/LineReviewManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/lineReview/LineReviewManager.java
@@ -41,10 +41,14 @@ public class LineReviewManager {
                 throw new CustomException(ErrorCode.LINEREVIEW_CREATE_DUPLICATE);
             }
 
+            // Todo : userId로 등록한 시큐리티에서 user 닉네임 가져오기 -> builder .writerNickname에 넣기
+            String writerNickname = "temp";         // 임시 닉네임
+
             LineReview lineReview = LineReview.builder()
                     .userId(userId)
                     .movieId(req.movieId())
                     .rating(req.rating())
+                    .writerNickname(writerNickname)
                     .context(req.context())
                     .isSpoiler(req.isSpoiler())
                     .build();

--- a/src/main/java/com/ureca/picky_be/jpa/board/Board.java
+++ b/src/main/java/com/ureca/picky_be/jpa/board/Board.java
@@ -32,6 +32,8 @@ public class Board extends BaseEntity {
 
     private boolean isSpoiler;
 
+    @Column(nullable=false)
+    private String writerName;
 
     public void updateBoard(String context, boolean isSpoiler) {
         this.context = context;

--- a/src/main/java/com/ureca/picky_be/jpa/board/Board.java
+++ b/src/main/java/com/ureca/picky_be/jpa/board/Board.java
@@ -33,20 +33,21 @@ public class Board extends BaseEntity {
     private boolean isSpoiler;
 
     @Column(nullable=false)
-    private String writerName;
+    private String writerNickname;
 
     public void updateBoard(String context, boolean isSpoiler) {
         this.context = context;
         this.isSpoiler = isSpoiler;
     }
 
-    public static Board of(Long userId, Movie movie, String context, boolean isSpoiler, List<AddBoardContentReq> addBoardContentReqs) {
+    public static Board of(Long userId, Movie movie, String context, boolean isSpoiler, List<AddBoardContentReq> addBoardContentReqs, String writerNickname) {
 
         Board board = Board.builder()
                 .userId(userId)
                 .movie(movie)
                 .context(context)
                 .isSpoiler(isSpoiler)
+                .writerNickname(writerNickname)
                 .contents(new ArrayList<>())
                 .build();
 

--- a/src/main/java/com/ureca/picky_be/jpa/board/BoardComment.java
+++ b/src/main/java/com/ureca/picky_be/jpa/board/BoardComment.java
@@ -28,15 +28,16 @@ public class BoardComment extends BaseEntity {
     private String context;
 
     @Column(nullable=false)
-    private String writerName;
+    private String writerNickname;
 
 
 
-    public static BoardComment of(Board board, Long userId, String context){
+    public static BoardComment of(Board board, Long userId, String context, String writerNickname){
         return BoardComment.builder()
-                .board(board)
-                .userId(userId)
                 .context(context)
+                .board(board)
+                .writerNickname(writerNickname)
+                .userId(userId)
                 .build();
     }
 }

--- a/src/main/java/com/ureca/picky_be/jpa/board/BoardComment.java
+++ b/src/main/java/com/ureca/picky_be/jpa/board/BoardComment.java
@@ -27,6 +27,11 @@ public class BoardComment extends BaseEntity {
     @Column(nullable = false)
     private String context;
 
+    @Column(nullable=false)
+    private String writerName;
+
+
+
     public static BoardComment of(Board board, Long userId, String context){
         return BoardComment.builder()
                 .board(board)

--- a/src/main/java/com/ureca/picky_be/jpa/lineReview/LineReview.java
+++ b/src/main/java/com/ureca/picky_be/jpa/lineReview/LineReview.java
@@ -36,6 +36,9 @@ public class LineReview extends BaseEntity {
 
     private boolean isDeleted;
 
+    @Column(nullable=false)
+    private String writerName;
+
     public void lineReviewContextUpdate(String context, Boolean isSpoiler) {
         this.context = context;
         this.isSpoiler = isSpoiler;

--- a/src/main/java/com/ureca/picky_be/jpa/lineReview/LineReview.java
+++ b/src/main/java/com/ureca/picky_be/jpa/lineReview/LineReview.java
@@ -37,7 +37,7 @@ public class LineReview extends BaseEntity {
     private boolean isDeleted;
 
     @Column(nullable=false)
-    private String writerName;
+    private String writerNickname;
 
     public void lineReviewContextUpdate(String context, Boolean isSpoiler) {
         this.context = context;


### PR DESCRIPTION
## 📝 관련 이슈
- [UP-106]  #64 
</br>

## 💻 작업 내용
- 게시글(Board), 댓글(BoardComment), 한줄평(lineReview) 엔티티에 writer_nickname 필드 추가
</br>

## 🙇 특이 사항
- 현재 temp라는 걸로 임시 생성해서 builder에 추가했는데 차후 예진이가 Security 관련해서 구현하면 거기에서 userNickname만 뽑아서 쓰는 걸로 수정하시면 됩니다!
- TODO로 주석 달아둠
</br>

## 👻 리뷰 요구사항 (선택)
- 
</br>

## pr 체크리스트
- [x] 담당자 & 리뷰어 & label 설정
- [x] 제목 규칙 준수 및 예시 삭제
- [x] 코드 정상 실행 확인
