### PR TITLE
[UP-105] SecurityContextHolder에 유저 정보 추가

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/implementation/auth/AuthManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/auth/AuthManager.java
@@ -2,6 +2,7 @@ package com.ureca.picky_be.base.implementation.auth;
 
 import com.ureca.picky_be.global.exception.CustomException;
 import com.ureca.picky_be.global.exception.ErrorCode;
+import com.ureca.picky_be.global.web.CustomUserDetails;
 import com.ureca.picky_be.jpa.user.Role;
 import org.springframework.security.core.GrantedAuthority;
 import org.springframework.security.core.context.SecurityContextHolder;
@@ -9,14 +10,29 @@ import org.springframework.stereotype.Component;
 
 @Component
 public class AuthManager {
-    public Long getUserId(){
-        return Long.parseLong(SecurityContextHolder.getContext().getAuthentication().getName());
+
+    private CustomUserDetails getCurrentUserDetails() {
+        return (CustomUserDetails) SecurityContextHolder.getContext()
+                .getAuthentication()
+                .getPrincipal();
     }
-    public Role getUserRole(){
-        return Role.fromString(SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
+    public Long getUserId() {
+        return getCurrentUserDetails().getId();
+    }
+
+    public Role getUserRole() {
+        return SecurityContextHolder.getContext().getAuthentication().getAuthorities().stream()
                 .findFirst()
                 .map(GrantedAuthority::getAuthority)
-                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED)));
+                .map(Role::fromString)
+                .orElseThrow(() -> new CustomException(ErrorCode.UNAUTHORIZED));
+    }
 
+    public String getUserNickname() {
+        return getCurrentUserDetails().getNickname();
+    }
+
+    public String getUserName() {
+        return getCurrentUserDetails().getUsername(); // name == username
     }
 }

--- a/src/main/java/com/ureca/picky_be/global/web/CustomUserDetails.java
+++ b/src/main/java/com/ureca/picky_be/global/web/CustomUserDetails.java
@@ -1,0 +1,70 @@
+package com.ureca.picky_be.global.web;
+
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+
+public class CustomUserDetails implements UserDetails {
+
+    private final Long id;
+    private final String username;
+    private final String nickname;
+    private final String role;
+    private final Collection<? extends GrantedAuthority> authorities;
+
+    public CustomUserDetails(Long id, String username, String nickname, String role, Collection<? extends GrantedAuthority> authorities) {
+        this.id = id;
+        this.username = username;
+        this.nickname = nickname;
+        this.role = role;
+        this.authorities = authorities;
+    }
+
+    public Long getId() {
+        return id;
+    }
+
+    public String getNickname() {
+        return nickname;
+    }
+
+    public String getRole() {
+        return role;
+    }
+
+    @Override
+    public String getUsername() {
+        return username;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return authorities;
+    }
+
+    @Override
+    public String getPassword() {
+        return ""; // 비밀번호는 사용하지 않음
+    }
+}

--- a/src/main/java/com/ureca/picky_be/global/web/CustomUserDetailsService.java
+++ b/src/main/java/com/ureca/picky_be/global/web/CustomUserDetailsService.java
@@ -23,11 +23,14 @@ public class CustomUserDetailsService implements UserDetailsService {
         Long userId = Long.parseLong(username);
 
         return userRepository.findById(userId)
-                .map(user -> new org.springframework.security.core.userdetails.User(
-                        user.getId().toString(),
-                        user.getRole().toString(),
+                .map(user -> new CustomUserDetails(
+                        user.getId(),
+                        user.getName(),
+                        user.getNickname(),
+                        user.getRole().name(),
                         List.of(new SimpleGrantedAuthority(user.getRole().name()))
                 ))
-                .orElseThrow(() -> new UsernameNotFoundException(username));
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with ID: " + username));
     }
 }
+


### PR DESCRIPTION

## 📝 관련 이슈
- [UP-#] #63 
</br>

## 💻 작업 내용
- SecurityContextHolder에 유저 정보 추가
</br>

## 🙇 특이 사항
- AuthManager에서 사용하시면 됩니다!
</br>

## 👻 리뷰 요구사항 (선택)
- 
</br>

## pr 체크리스트
- [ ] 담당자 & 리뷰어 & label 설정
- [ ] 제목 규칙 준수 및 예시 삭제
- [ ] 코드 정상 실행 확인
