### PR TITLE
[BE][UP-176] 마이페이지 유저 닉네임으로 작성 게시글 수, 팔로워 수, 팔로잉 수 조회 API

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/business/user/UserService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/user/UserService.java
@@ -1,9 +1,11 @@
 package com.ureca.picky_be.base.business.user;
 
+import com.ureca.picky_be.base.business.user.dto.GetMyPageUserInfoResp;
 import com.ureca.picky_be.base.business.user.dto.GetNicknameValidationResp;
 import com.ureca.picky_be.base.business.user.dto.GetUserResp;
 import com.ureca.picky_be.base.business.user.dto.RegisterUserReq;
 import com.ureca.picky_be.base.implementation.auth.AuthManager;
+import com.ureca.picky_be.base.implementation.board.BoardManager;
 import com.ureca.picky_be.base.implementation.content.ImageManager;
 import com.ureca.picky_be.base.implementation.mapper.UserDtoMapper;
 import com.ureca.picky_be.base.implementation.user.UserManager;
@@ -23,6 +25,7 @@ public class UserService implements UserUseCase {
     private final UserDtoMapper userDtoMapper;
     private final AuthManager authManager;
     private final ImageManager imageManager;
+    private final BoardManager boardManager;
 
     @Override
     public SuccessCode registerUserInfo(RegisterUserReq req) {
@@ -53,6 +56,16 @@ public class UserService implements UserUseCase {
     @Override
     public GetNicknameValidationResp getNicknameValidation(String nickname){
         return userDtoMapper.toGetNicknameValidationResp(userManager.getNicknameValidation(nickname));
+    }
+
+    @Override
+    public GetMyPageUserInfoResp getMyPageUserInfo(String nickname) {
+        Long userId = userManager.getUserIdByNickname(nickname);
+        Integer boardCount = boardManager.getUserBoardCount(userId);
+        Integer followerCount = userManager.getUserFollowerCount(userId);
+        Integer followingCount = userManager.getUserFollowingCount(userId);
+
+        return new GetMyPageUserInfoResp(userId, boardCount, followerCount, followingCount);
     }
 
 

--- a/src/main/java/com/ureca/picky_be/base/business/user/UserUseCase.java
+++ b/src/main/java/com/ureca/picky_be/base/business/user/UserUseCase.java
@@ -1,5 +1,6 @@
 package com.ureca.picky_be.base.business.user;
 
+import com.ureca.picky_be.base.business.user.dto.GetMyPageUserInfoResp;
 import com.ureca.picky_be.base.business.user.dto.GetNicknameValidationResp;
 import com.ureca.picky_be.base.business.user.dto.GetUserResp;
 import com.ureca.picky_be.base.business.user.dto.RegisterUserReq;
@@ -15,4 +16,5 @@ public interface UserUseCase {
     GetUserResp getUserInfo();
     GetNicknameValidationResp getNicknameValidation(String nickname);
 
+    GetMyPageUserInfoResp getMyPageUserInfo(String nickname);
 }

--- a/src/main/java/com/ureca/picky_be/base/business/user/dto/GetMyPageUserInfoResp.java
+++ b/src/main/java/com/ureca/picky_be/base/business/user/dto/GetMyPageUserInfoResp.java
@@ -1,0 +1,9 @@
+package com.ureca.picky_be.base.business.user.dto;
+
+public record GetMyPageUserInfoResp(
+        Long userId,
+        Integer boardCount,
+        Integer followerCount,
+        Integer followingCount
+) {
+}

--- a/src/main/java/com/ureca/picky_be/base/implementation/board/BoardManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/board/BoardManager.java
@@ -244,6 +244,12 @@ public class BoardManager {
         }
     }
 
-
-
+    @Transactional(readOnly = true)
+    public Integer getUserBoardCount(Long userId) {
+        try{
+            return boardRepository.countByUserId(userId);
+        } catch (Exception e) {
+            throw new CustomException(ErrorCode.BOARD_COUNT_FAIL);
+        }
+    }
 }

--- a/src/main/java/com/ureca/picky_be/base/implementation/mapper/UserDtoMapper.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/mapper/UserDtoMapper.java
@@ -1,5 +1,6 @@
 package com.ureca.picky_be.base.implementation.mapper;
 
+import com.ureca.picky_be.base.business.user.dto.GetMyPageUserInfoResp;
 import com.ureca.picky_be.base.business.user.dto.GetNicknameValidationResp;
 import com.ureca.picky_be.base.business.user.dto.GetUserResp;
 import com.ureca.picky_be.jpa.genre.Genre;

--- a/src/main/java/com/ureca/picky_be/base/implementation/user/UserManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/user/UserManager.java
@@ -2,6 +2,7 @@ package com.ureca.picky_be.base.implementation.user;
 
 import com.ureca.picky_be.base.business.user.dto.RegisterUserReq;
 import com.ureca.picky_be.base.implementation.content.ProfileManager;
+import com.ureca.picky_be.base.persistence.follow.FollowRepository;
 import com.ureca.picky_be.base.persistence.movie.GenreRepository;
 import com.ureca.picky_be.base.persistence.movie.MovieLikeRepository;
 import com.ureca.picky_be.base.persistence.movie.MovieRepository;
@@ -30,7 +31,9 @@ public class UserManager {
     private final GenreRepository genreRepository;
     private final MovieLikeRepository movieLikeRepository;
     private final MovieRepository movieRepository;
+    private final FollowRepository followRepository;
     private final ProfileManager profileManager;
+
 
     @Transactional
     public SuccessCode registerProfile(MultipartFile profile, Long userId) throws IOException {
@@ -178,7 +181,19 @@ public class UserManager {
         return !userRepository.existsByNickname(nickname);
     }
 
+    @Transactional(readOnly = true)
     public Long getUserIdByNickname(String nickname) {
         return userRepository.findByNickname(nickname);
+    }
+
+
+    @Transactional(readOnly = true)
+    public Integer getUserFollowerCount(Long userId) {
+        return followRepository.countByFollowerId(userId);
+    }
+
+    @Transactional(readOnly = true)
+    public Integer getUserFollowingCount(Long userId) {
+        return followRepository.countByFollowingId(userId);
     }
 }

--- a/src/main/java/com/ureca/picky_be/base/persistence/board/BoardRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/board/BoardRepository.java
@@ -2,12 +2,9 @@ package com.ureca.picky_be.base.persistence.board;
 
 import com.ureca.picky_be.base.business.board.dto.BoardCommentProjection;
 import com.ureca.picky_be.base.business.board.dto.BoardProjection;
-import com.ureca.picky_be.base.business.board.dto.commentDto.GetAllBoardCommentsResp;
 import com.ureca.picky_be.jpa.board.Board;
-import com.ureca.picky_be.jpa.board.BoardContent;
 import com.ureca.picky_be.jpa.config.IsDeleted;
 import org.springframework.data.annotation.ReadOnlyProperty;
-import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.domain.Slice;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -99,6 +96,7 @@ public interface BoardRepository extends JpaRepository<Board, Long> {
     """)
     Slice<BoardProjection> findByIdAndCursor(@Param("userId") Long userId, @Param("lastBoardId") Long lastBoardId, Pageable pageable);
 
+    Integer countByUserId(Long userId);
 
 
 

--- a/src/main/java/com/ureca/picky_be/base/persistence/follow/FollowRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/follow/FollowRepository.java
@@ -7,4 +7,7 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface FollowRepository extends JpaRepository<Follow, Long> {
 
+    Integer countByFollowerId(Long userId);
+    Integer countByFollowingId(Long userId);
+
 }

--- a/src/main/java/com/ureca/picky_be/base/persistence/follow/FollowRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/follow/FollowRepository.java
@@ -1,0 +1,10 @@
+package com.ureca.picky_be.base.persistence.follow;
+
+import com.ureca.picky_be.jpa.follow.Follow;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface FollowRepository extends JpaRepository<Follow, Long> {
+
+}

--- a/src/main/java/com/ureca/picky_be/base/persistence/user/UserRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/user/UserRepository.java
@@ -16,4 +16,7 @@ public interface UserRepository extends JpaRepository<User, Long> {
 
     @Query("SELECT u.id AS id FROM User u WHERE u.nickname = :nickname")
     Long findByNickname(@Param("nickname") String nickname);
+
+
+
 }

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/user/UserController.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/user/UserController.java
@@ -59,5 +59,11 @@ public class UserController {
         return userUseCase.getNicknameValidation(nickname);
     }
 
+    @Operation(summary = "닉네임으로 마이페이지 접속시 데이터(게시글 수, 팔로워, 팔로잉 수) 조회", description = "nickname으로 해당 사용자에 대한 정보를 조회하는 API입니다.")
+    @PatchMapping("/mypage/{nickname}")
+    public GetMyPageUserInfoResp updateUserInfo(@PathVariable String nickname) {
+        return userUseCase.getMyPageUserInfo(nickname);
+    }
+
 
 }

--- a/src/main/java/com/ureca/picky_be/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/picky_be/config/SecurityConfig.java
@@ -60,6 +60,7 @@ public class SecurityConfig {
 
             // USER
             "/api/v1/user",
+            "/api/v1/user/mypage/*",
 
             // NOTIFICATION
             "/api/v1/notification/connect",

--- a/src/main/java/com/ureca/picky_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/ureca/picky_be/global/exception/ErrorCode.java
@@ -47,6 +47,7 @@ public enum ErrorCode {
     BOARD_DELETE_FAILED(HttpStatus.BAD_REQUEST, "BOD006", "게시물 삭제에 실패했습니다."),
     BOARD_IS_DELETED(HttpStatus.BAD_REQUEST, "BOD007", "삭제된 게시물입니다."),
     BOARD_USER_ID_GET_FAILED(HttpStatus.BAD_REQUEST, "BOD009", "특정 사용자가 작성한 게시물들을 가져오는데에 실패했습니다."),
+    BOARD_COUNT_FAIL(HttpStatus.BAD_REQUEST, "BOD010", "특정 사용자가 작성한 게시물 갯수를 가져오는데에 실패했습니다."),
 
     // BOARD_CONTENT
     INVALID_CONTENT_TYPE(HttpStatus.BAD_REQUEST, "BDC001","PHOTO, VIDEO값만 가능합니다"),

--- a/src/main/java/com/ureca/picky_be/jpa/follow/Follow.java
+++ b/src/main/java/com/ureca/picky_be/jpa/follow/Follow.java
@@ -1,7 +1,6 @@
-package com.ureca.picky_be.jpa.following;
+package com.ureca.picky_be.jpa.follow;
 
 import com.ureca.picky_be.jpa.config.BaseEntity;
-import com.ureca.picky_be.jpa.user.User;
 import jakarta.persistence.*;
 import lombok.*;
 

--- a/src/main/java/com/ureca/picky_be/jpa/follow/Follow.java
+++ b/src/main/java/com/ureca/picky_be/jpa/follow/Follow.java
@@ -17,10 +17,10 @@ public class Follow extends BaseEntity {
     private Long id;
 
     @Column(name = "follower_id", nullable = false)
-    private Long followerId;
+    private Long followerId;        // 신청자(상대한테 신청하는 사람)
 
     @Column(name = "following_id", nullable = false)
-    private Long followingId;
+    private Long followingId;       // 수령자(누군가의 신청을 받는 사람)
 
 
 }


### PR DESCRIPTION


## 📝 관련 이슈
- [UP-176] #121 
</br>

## 💻 작업 내용
- userController에 닉네임으로 해당 사용자의 게시글 수, 팔로워, 팔로잉 수 조회하는 API 개발
- followRepository 생성
</br>

## 🙇 특이 사항
- followRepository를 만들어서 팔로우 관련한 리포는 저거 쓰면 됩니다!
- 마이페이지라서 userController, 즉 유저 도메인쪽에 생성했는데 어떤가요?
</br>

## 👻 리뷰 요구사항 (선택)
- 
</br>

## pr 체크리스트
- [x] 담당자 & 리뷰어 & label 설정
- [x] 제목 규칙 준수 및 예시 삭제
- [x] 코드 정상 실행 확인
