### PR TITLE
[BE][UP-189] LineReview 관련 조회 API들에 isAuthor 추가

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/business/board/BoardService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/board/BoardService.java
@@ -72,7 +72,6 @@ public class BoardService implements BoardUseCase {
         return SuccessCode.CREATE_BOARD_SUCCESS;
     }
 
-
     @Override
     @Transactional
     public void updateBoard(Long boardId , UpdateBoardReq req) {

--- a/src/main/java/com/ureca/picky_be/base/business/lineReview/LineReviewService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/lineReview/LineReviewService.java
@@ -43,7 +43,8 @@ public class LineReviewService implements LineReviewUseCase {
     @Override
     @Transactional(readOnly = true)
     public Slice<ReadLineReviewResp> getLineReviewsByMovie(PageRequest pageRequest, LineReviewQueryRequest queryReq) {
-        Slice<LineReviewProjection> lineReviews = lineReviewManager.findLineReviewsByMovie(queryReq, pageRequest);
+        Long userId = authManager.getUserId();
+        Slice<LineReviewProjection> lineReviews = lineReviewManager.findLineReviewsByMovie(userId, queryReq, pageRequest);
         return lineReviews.map(lineReviewDtoMapper::toReadLineReviewResp);
     }
 

--- a/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/GetUserLineReviewResp.java
+++ b/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/GetUserLineReviewResp.java
@@ -12,6 +12,7 @@ public record GetUserLineReviewResp(
         Integer likes,         // 좋아요 수
         Integer dislikes,         // 좋아요 수
         LocalDateTime createdAt, // 생성 시간
-        LineReviewMovieInfo movie   //
+        LineReviewMovieInfo movie,   // 영화 정보
+        boolean isAuthor    // 작성자 여부
 ) {
 }

--- a/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/LineReviewProjection.java
+++ b/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/LineReviewProjection.java
@@ -13,4 +13,5 @@ public interface LineReviewProjection {
     Integer getLikes();
     Integer getDislikes();// 좋아요 수
     LocalDateTime getCreatedAt(); // 생성 시간
+    boolean getIsAuthor(); // 작성자 여부
 }

--- a/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/MyPageLineReviewProjection.java
+++ b/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/MyPageLineReviewProjection.java
@@ -15,4 +15,6 @@ public interface MyPageLineReviewProjection {
     Integer getLikes();
     Integer getDislikes();// 좋아요 수
     LocalDateTime getCreatedAt(); // 생성 시간
+    boolean getIsAuthor();      // 작성자 일치 여부
+
 }

--- a/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/ReadLineReviewResp.java
+++ b/src/main/java/com/ureca/picky_be/base/business/lineReview/dto/ReadLineReviewResp.java
@@ -11,6 +11,7 @@ public record ReadLineReviewResp(Long id,
                                  Boolean isSpoiler, // 스포일러 여부
                                  Integer likes,         // 좋아요 수
                                  Integer dislikes,         // 좋아요 수
-                                 LocalDateTime createdAt // 생성 시간
+                                 LocalDateTime createdAt, // 생성 시간
+                                 boolean isAuthor   // 작성자 boolean
 ) {
 }

--- a/src/main/java/com/ureca/picky_be/base/implementation/lineReview/LineReviewManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/lineReview/LineReviewManager.java
@@ -77,14 +77,13 @@ public class LineReviewManager {
     }
 
 
-    public Slice<LineReviewProjection> findLineReviewsByMovie(LineReviewQueryRequest queryReq, PageRequest pageRequest) {
+    public Slice<LineReviewProjection> findLineReviewsByMovie(Long userId, LineReviewQueryRequest queryReq, PageRequest pageRequest) {
         try {
             // 요청 데이터 변수로 저장 (가독성 향상)
             Long movieId = queryReq.movieId();
             Long lastReviewId = queryReq.lastReviewId();
             LocalDateTime lastCreatedAt = queryReq.lastCreatedAt();
             SortType sortType = queryReq.sortType();
-
             // 영화 존재 여부 확인
             if (!movieRepository.existsById(movieId)) {
                 throw new CustomException(ErrorCode.MOVIE_NOT_FOUND);
@@ -96,9 +95,9 @@ public class LineReviewManager {
             // 정렬 타입에 따라 쿼리 호출
             switch (sortType) {
                 case LIKES:
-                    return lineReviewRepository.findByMovieAndLikesCursor(movieId, lastReviewId, pageRequest);
+                    return lineReviewRepository.findByMovieAndLikesCursor(userId, movieId, lastReviewId, pageRequest);
                 case LATEST:
-                    return lineReviewRepository.findByMovieAndLatestCursor(movieId, lastReviewId, lastCreatedAt, pageRequest);
+                    return lineReviewRepository.findByMovieAndLatestCursor(movieId, lastReviewId, lastCreatedAt, userId, pageRequest);
                 default:
                     throw new CustomException(ErrorCode.LINEREVIEW_INVALID_SORTTYPE);
             }

--- a/src/main/java/com/ureca/picky_be/base/implementation/lineReview/mapper/LineReviewDtoMapper.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/lineReview/mapper/LineReviewDtoMapper.java
@@ -62,7 +62,8 @@ public class LineReviewDtoMapper {
                     projection.getMovieId(),
                     projection.getMovieTitle(),
                     projection.getMoviePosterUrl()
-                )
+                ),
+                projection.getIsAuthor()
         );
     }
 

--- a/src/main/java/com/ureca/picky_be/base/implementation/lineReview/mapper/LineReviewDtoMapper.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/lineReview/mapper/LineReviewDtoMapper.java
@@ -42,7 +42,8 @@ public class LineReviewDtoMapper {
                 projection.getIsSpoiler(),
                 projection.getLikes(),
                 projection.getDislikes(),
-                projection.getCreatedAt()
+                projection.getCreatedAt(),
+                projection.getIsAuthor()
         );
     }
 

--- a/src/main/java/com/ureca/picky_be/base/persistence/lineReview/LineReviewRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/lineReview/LineReviewRepository.java
@@ -27,7 +27,8 @@ public interface LineReviewRepository extends JpaRepository<LineReview, Long> {
                lr.context AS context, lr.isSpoiler AS isSpoiler,
                COUNT(CASE WHEN lrl.preference = 'LIKE' AND lrl.isDeleted = false THEN lrl.id END) AS likes,
                COUNT(CASE WHEN lrl.preference = 'DISLIKE' AND lrl.isDeleted = false THEN lrl.id END) AS dislikes,
-               lr.createdAt AS createdAt
+               lr.createdAt AS createdAt,
+               (CASE WHEN lr.userId = :userId THEN true ELSE false END) AS isAuthor
         FROM LineReview lr
         LEFT JOIN LineReviewLike lrl ON lrl.lineReview.id = lr.id
         WHERE lr.movieId = :movieId
@@ -38,6 +39,7 @@ public interface LineReviewRepository extends JpaRepository<LineReview, Long> {
     Slice<LineReviewProjection> findByMovieAndLikesCursor(
             @Param("movieId") Long movieId,
             @Param("lastReviewId") Long lastReviewId,
+            @Param("userId") Long userId,
             Pageable pageable
     );
 
@@ -46,7 +48,8 @@ public interface LineReviewRepository extends JpaRepository<LineReview, Long> {
                lr.context AS context, lr.isSpoiler AS isSpoiler,
                COUNT(CASE WHEN lrl.preference = 'LIKE' AND lrl.isDeleted = false THEN lrl.id END) AS likes,
                COUNT(CASE WHEN lrl.preference = 'DISLIKE' AND lrl.isDeleted = false THEN lrl.id END) AS dislikes,
-               lr.createdAt AS createdAt
+               lr.createdAt AS createdAt,
+               (CASE WHEN lr.userId = :userId THEN true ELSE false END) AS isAuthor
         FROM LineReview lr
         LEFT JOIN LineReviewLike lrl ON lrl.lineReview.id = lr.id
         WHERE lr.movieId = :movieId
@@ -59,6 +62,7 @@ public interface LineReviewRepository extends JpaRepository<LineReview, Long> {
             @Param("movieId") Long movieId,
             @Param("lastReviewId") Long lastReviewId,
             @Param("lastCreatedAt") LocalDateTime lastCreatedAt,
+            @Param("userId") Long userId,
             Pageable pageable
     );
 

--- a/src/main/java/com/ureca/picky_be/base/persistence/lineReview/LineReviewRepository.java
+++ b/src/main/java/com/ureca/picky_be/base/persistence/lineReview/LineReviewRepository.java
@@ -71,7 +71,8 @@ public interface LineReviewRepository extends JpaRepository<LineReview, Long> {
                lr.context AS context, lr.isSpoiler AS isSpoiler,
                COUNT(CASE WHEN lrl.preference = 'LIKE' AND lrl.isDeleted = false THEN lrl.id END) AS likes,
                COUNT(CASE WHEN lrl.preference = 'DISLIKE' AND lrl.isDeleted = false THEN lrl.id END) AS dislikes,
-               lr.createdAt AS createdAt
+               lr.createdAt AS createdAt,
+               (CASE WHEN lr.userId = :userId THEN true ELSE false END) AS isAuthor
         FROM LineReview lr
         LEFT JOIN LineReviewLike lrl ON lrl.lineReview.id = lr.id
         LEFT JOIN Movie m ON lr.movieId = m.id

--- a/src/main/java/com/ureca/picky_be/config/SecurityConfig.java
+++ b/src/main/java/com/ureca/picky_be/config/SecurityConfig.java
@@ -71,6 +71,8 @@ public class SecurityConfig {
 
             // LINEREVIEW
             "/api/v1/linereview/*",
+            "/api/v1/linereview/movie/*",
+
 
     };
 
@@ -90,6 +92,7 @@ public class SecurityConfig {
             // LINEREVIEW
             "/api/v1/linereview/create",
             "/api/v1/linereview/*",
+            "/api/v1/linereview/movie/*",
     };
 
     private static final String[] AUTH_USER_PATCH = {


### PR DESCRIPTION

## 📝 관련 이슈
- [UP-189] #134 
</br>

## 💻 작업 내용
- LineReview 2개 API에 isAuthor 필드 추가
- /linereview/user/{nickname}
- /linereview/movie/{movieId}
</br>

## 🙇 특이 사항
- 
</br>

## 👻 리뷰 요구사항 (선택)
- 
</br>

## pr 체크리스트
- [x] 담당자 & 리뷰어 & label 설정
- [x] 제목 규칙 준수 및 예시 삭제
- [x] 코드 정상 실행 확인
