### PR TITLE
[BE][UP-Email] 회원가입, 이벤트용 이메일 전송 API 

### DIFF
--- a/src/main/java/com/ureca/picky_be/base/business/email/MailService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/email/MailService.java
@@ -2,6 +2,7 @@ package com.ureca.picky_be.base.business.email;
 
 import com.ureca.picky_be.base.implementation.email.EmailManager;
 import com.ureca.picky_be.base.implementation.user.UserManager;
+import com.ureca.picky_be.jpa.entity.user.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
@@ -16,5 +17,12 @@ public class MailService implements MailUseCase {
     public void createEmailAndSendToUser(Long userId) {
         String email = userManager.getUserEmailById(userId);
         emailManager.sendOneEmail(email);
+    }
+
+    @Override
+    public void sendRegisterCongratulationMail(Long userId) {
+//        String email = userManager.getUserEmailById(userId);
+        User user = userManager.getUserById(userId);
+        emailManager.sendRegisterContratulateEmail(user);
     }
 }

--- a/src/main/java/com/ureca/picky_be/base/business/email/MailService.java
+++ b/src/main/java/com/ureca/picky_be/base/business/email/MailService.java
@@ -1,5 +1,6 @@
 package com.ureca.picky_be.base.business.email;
 
+import com.ureca.picky_be.base.business.email.dto.EventMessageReq;
 import com.ureca.picky_be.base.implementation.email.EmailManager;
 import com.ureca.picky_be.base.implementation.user.UserManager;
 import com.ureca.picky_be.jpa.entity.user.User;
@@ -14,9 +15,9 @@ public class MailService implements MailUseCase {
     private final UserManager userManager;
 
     @Override
-    public void createEmailAndSendToUser(Long userId) {
+    public void sendEventEmail(Long userId, EventMessageReq req) {
         String email = userManager.getUserEmailById(userId);
-        emailManager.sendOneEmail(email);
+        emailManager.sendOneEmail(email, req);
     }
 
     @Override

--- a/src/main/java/com/ureca/picky_be/base/business/email/MailUseCase.java
+++ b/src/main/java/com/ureca/picky_be/base/business/email/MailUseCase.java
@@ -2,4 +2,6 @@ package com.ureca.picky_be.base.business.email;
 
 public interface MailUseCase {
     void createEmailAndSendToUser(Long userId);
+
+    void sendRegisterCongratulationMail(Long userId);
 }

--- a/src/main/java/com/ureca/picky_be/base/business/email/MailUseCase.java
+++ b/src/main/java/com/ureca/picky_be/base/business/email/MailUseCase.java
@@ -1,7 +1,9 @@
 package com.ureca.picky_be.base.business.email;
 
+import com.ureca.picky_be.base.business.email.dto.EventMessageReq;
+
 public interface MailUseCase {
-    void createEmailAndSendToUser(Long userId);
+    void sendEventEmail(Long userId, EventMessageReq req);
 
     void sendRegisterCongratulationMail(Long userId);
 }

--- a/src/main/java/com/ureca/picky_be/base/business/email/dto/EventMessageReq.java
+++ b/src/main/java/com/ureca/picky_be/base/business/email/dto/EventMessageReq.java
@@ -1,0 +1,6 @@
+package com.ureca.picky_be.base.business.email.dto;
+
+public record EventMessageReq(
+        String eventMessage
+) {
+}

--- a/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
@@ -1,6 +1,7 @@
 package com.ureca.picky_be.base.implementation.email;
 
 
+import com.ureca.picky_be.base.business.email.dto.EventMessageReq;
 import com.ureca.picky_be.global.exception.CustomException;
 import com.ureca.picky_be.global.exception.ErrorCode;
 import com.ureca.picky_be.jpa.entity.user.User;
@@ -22,13 +23,13 @@ public class EmailManager {
 
 
     @Async("customExecutor")
-    public void sendOneEmail(String to) {
+    public void sendOneEmail(String to, EventMessageReq req) {
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
 
             // 수신자, 제목, 본문 등 설정
             String subject = "[PICKY] 이벤트 및 이메일 전송 안내";
-            String body = "PICKY 이메일 전송 및 이벤트 안내를 위해 발송된 메일입니다.";
+            String body = req.eventMessage();
 
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
             mimeMessageHelper.setTo(to);
@@ -36,7 +37,6 @@ public class EmailManager {
             mimeMessageHelper.setText(body, true);
 
             // Email 전송
-
             mailSender.send(mimeMessage);
 
         } catch (MessagingException e){

--- a/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
@@ -3,6 +3,7 @@ package com.ureca.picky_be.base.implementation.email;
 
 import com.ureca.picky_be.global.exception.CustomException;
 import com.ureca.picky_be.global.exception.ErrorCode;
+import com.ureca.picky_be.jpa.entity.user.User;
 import jakarta.mail.MessagingException;
 import jakarta.mail.internet.MimeMessage;
 import lombok.RequiredArgsConstructor;
@@ -30,6 +31,45 @@ public class EmailManager {
 
             MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
             mimeMessageHelper.setTo(to);
+            mimeMessageHelper.setSubject(subject);
+            mimeMessageHelper.setText(body, true);
+
+            // Email 전송
+            mailSender.send(mimeMessage);
+
+        } catch (MessagingException e){
+            throw new CustomException(ErrorCode.EMAIL_SEND_FAILED);
+        }
+    }
+
+
+    public void sendRegisterContratulateEmail(User user) {
+        String email = user.getEmail();
+        if(email == null || email.isEmpty()) {
+            throw new CustomException(ErrorCode.USER_EMAIL_EMPTY);
+        }
+
+
+        String name = user.getName();
+        if(name == null || name.isEmpty()) {
+            throw new CustomException(ErrorCode.USER_NAME_NOT_FOUND);
+        }
+
+        try {
+            MimeMessage mimeMessage = mailSender.createMimeMessage();
+
+            // 수신자, 제목, 본문 등 설정
+            String subject = "[PICKY] 회원가입 이메일 안내";
+            String body = "안녕하세요. " + name + "님!\n\n"
+                    + "PICKY 회원가입을 축하합니다.\n\n"
+                    + "※유의 사항 안내\n"
+                    + "본 이메일은 발신 전용이므로 회신이 되지 않습니다.\n"
+                    + "추가 문의사항은 1:1 문의하기 기능을 통해 접수해주시면 감사하겠습니다. : )\n\n"
+                    + "감사합니다.\n"
+                    + "PICKY 드림";
+
+            MimeMessageHelper mimeMessageHelper = new MimeMessageHelper(mimeMessage);
+            mimeMessageHelper.setTo(email);
             mimeMessageHelper.setSubject(subject);
             mimeMessageHelper.setText(body, true);
 

--- a/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/email/EmailManager.java
@@ -20,7 +20,8 @@ import org.springframework.transaction.annotation.Transactional;
 public class EmailManager {
     private final JavaMailSender mailSender;
 
-    @Async
+
+    @Async("customExecutor")
     public void sendOneEmail(String to) {
         try {
             MimeMessage mimeMessage = mailSender.createMimeMessage();
@@ -35,6 +36,7 @@ public class EmailManager {
             mimeMessageHelper.setText(body, true);
 
             // Email 전송
+
             mailSender.send(mimeMessage);
 
         } catch (MessagingException e){

--- a/src/main/java/com/ureca/picky_be/base/implementation/user/UserManager.java
+++ b/src/main/java/com/ureca/picky_be/base/implementation/user/UserManager.java
@@ -206,4 +206,14 @@ public class UserManager {
             throw new CustomException(ErrorCode.USER_EMAIL_EMPTY);
         return user.getEmail();
     }
+
+    @Transactional(readOnly = true)
+    public User getUserById(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new CustomException(ErrorCode.USER_NOT_FOUND));
+
+        if(user.getEmail() == null || user.getEmail().isEmpty())
+            throw new CustomException(ErrorCode.USER_EMAIL_EMPTY);
+        return user;
+    }
 }

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/email/EmailController.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/email/EmailController.java
@@ -23,4 +23,15 @@ public class EmailController {
         mailUseCase.createEmailAndSendToUser(userId);
         return SuccessCode.EMAIL_SEND_SUCCESS;
     }
+
+    @Operation(summary = "회원가입 이메일 전송 API", description = "회원가입시 환영을 위한 이메일")
+    @PostMapping("/register")
+    public SuccessCode sendRegisterCongratulationsEmail(
+            @Parameter(description = "보내려하는 사람의 id")
+            @RequestParam Long userId)
+    {
+        mailUseCase.sendRegisterCongratulationMail(userId);
+        return SuccessCode.EMAIL_SEND_SUCCESS;
+    }
+
 }

--- a/src/main/java/com/ureca/picky_be/base/presentation/controller/email/EmailController.java
+++ b/src/main/java/com/ureca/picky_be/base/presentation/controller/email/EmailController.java
@@ -1,6 +1,7 @@
 package com.ureca.picky_be.base.presentation.controller.email;
 
 import com.ureca.picky_be.base.business.email.MailUseCase;
+import com.ureca.picky_be.base.business.email.dto.EventMessageReq;
 import com.ureca.picky_be.global.success.SuccessCode;
 import io.swagger.v3.oas.annotations.Operation;
 import io.swagger.v3.oas.annotations.Parameter;
@@ -14,13 +15,15 @@ public class EmailController {
 
     private final MailUseCase mailUseCase;
 
-    @Operation(summary = "이메일 전송 API", description = "아직 어떤 용도로 전송할 것인지 정하지 못함")
-    @PostMapping
-    public SuccessCode sendEmail(
+    @Operation(summary = "이벤트 이메일 전송 API", description = "특정 이벤트에 대한 이메일")
+    @PostMapping("/event")
+    public SuccessCode sendEventEmail(
             @Parameter(description = "보내려하는 사람의 id")
-            @RequestParam Long userId)
+            @RequestParam Long userId,
+            @RequestBody EventMessageReq req
+    )
     {
-        mailUseCase.createEmailAndSendToUser(userId);
+        mailUseCase.sendEventEmail(userId, req);
         return SuccessCode.EMAIL_SEND_SUCCESS;
     }
 

--- a/src/main/java/com/ureca/picky_be/config/AsyncConfig.java
+++ b/src/main/java/com/ureca/picky_be/config/AsyncConfig.java
@@ -18,18 +18,18 @@ public class AsyncConfig implements AsyncConfigurer {
         executor.setCorePoolSize(5); // thread-pool에 항상 살아있는 thread 최소 개수
         executor.setMaxPoolSize(5); // thread-pool에서 사용 가능한 최대 thread 개수
         executor.setQueueCapacity(500); // thread-pool에서 사용할 최대 queue 크기
-        executor.setThreadNamePrefix("custom-task-");
+        executor.setThreadNamePrefix("Notification Executor");
         executor.initialize();
         return executor;
     }
 
-    @Bean
+    @Bean(name = "customExecutor")
     public Executor customExecutor() {
         ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
         executor.setCorePoolSize(5); // thread-pool에 항상 살아있는 thread 최소 개수
         executor.setMaxPoolSize(5); // thread-pool에서 사용 가능한 최대 thread 개수
         executor.setQueueCapacity(500); // thread-pool에서 사용할 최대 queue 크기
-        executor.setThreadNamePrefix("method-task");
+        executor.setThreadNamePrefix("Email Executor");
         executor.initialize();
         return executor;
     }

--- a/src/main/java/com/ureca/picky_be/global/exception/ErrorCode.java
+++ b/src/main/java/com/ureca/picky_be/global/exception/ErrorCode.java
@@ -26,6 +26,7 @@ public enum ErrorCode {
     USER_UPDATE_BAD_REQUEST(HttpStatus.BAD_REQUEST, "USR005", "입력할 정보가 존재하지 않습니다"),
     NO_USER_FOUND(HttpStatus.BAD_REQUEST, "USR006", "해당 조건을 만족하는 유저가 없습니다."),
     NO_DATA_RECEIVED(HttpStatus.BAD_REQUEST, "USR007", "업데이트할 데이터를 받지 못했습니다."),
+    USER_NAME_NOT_FOUND(HttpStatus.BAD_REQUEST, "USR008", "해당 유저의 이름이 존재하지 않습니다."),
 
     // GENRE
     GENRE_NOT_FOUND(HttpStatus.NOT_FOUND, "GEN001", "해당 영화 장르를 찾지 못했습니다."),


### PR DESCRIPTION

## 📝 관련 이슈
- [UP-Mail] #152 
</br>

## 💻 작업 내용
- 회원가입시 축하 이메일 기능 구현
- 이벤트용 알림으로 RequestBody를 통해 내용 수정 가능하도록 구현
</br>

## 🙇 특이 사항
- 비동기로 돌려서 최대한 사용성에 지장 없도록 제작했습니다.
</br>

## 👻 리뷰 요구사항 (선택)
- 
</br>

## pr 체크리스트
- [x] 담당자 & 리뷰어 & label 설정
- [x] 제목 규칙 준수 및 예시 삭제
- [x] 코드 정상 실행 확인
